### PR TITLE
Use stRange to provide full-featured Range class

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Then make a query that returns range objects!
 ```javascript
 client.query("SELECT range FROM table", function (result) {
   // result.range = {
-  //   lower: Thu Mar 26 2014 17:57:02 GMT-0400 (EDT),
-  //   upper: Thu Mar 27 2014 17:57:02 GMT-0400 (EDT),
+  //   begin: Thu Mar 26 2014 17:57:02 GMT-0400 (EDT),
+  //   end: Thu Mar 27 2014 17:57:02 GMT-0400 (EDT),
   //   bounds: '[)'
   // }
 });
@@ -36,9 +36,13 @@ var Range = require("pg-range").Range;
 client.query("INSERT INTO table VALUES ($1)", [Range(1, 3)]);
 ```
 
-See the Postgres  ["Range Types" documentation][postgres-docs] for details.
+See the Postgres ["Range Types" documentation][postgres-docs] for details.
 
 ### Range objects
+
+pg-range uses [stRange.js][strange], a JavaScript range library, to provide a
+`Range` class with useful methods, like `contains` and `intersects`.
+See the [stRange.js API documentation][strange-docs].
 
 Values of (PostgreSQL) type
 
@@ -49,96 +53,17 @@ Values of (PostgreSQL) type
 * `tstzrange`
 * `daterange`
 
-will be automatically parsed into instances of `Range`.
+will be automatically parsed into instances of `Range` when the pg-range
+type adapter is installed.
 
-#### Construction
-
-Finite integer range with default bounds:
-
-```javascript
-Range(1, 3)
-```
-
-Explicit bounds:
-
-```javascript
-Range(1, 3, "(]")
-Range(1, 7, "()")
-```
-
-Date ranges:
-
-```javascript
-Range(new Date(2014, 0, 1), new Date(2014, 1, 1))
-```
-
-Infinite ranges:
-
-```javascript
-Range(1, null)
-Range(null, 7)
-Range(null, null)
-```
-
-Empty range:
-
-```javascript
-Range()
-```
-
-Range is a naive class; instances need not be valid PostgreSQL ranges or even
-sensible. This is perfectly valid
-
-```javascript
-Range(-7, new Date(2014, 1, 1))
-```
-
-and won't fail until you try to use it in a query.
-
-#### Properties
-
-##### `lower` *varies*
-
-The lower bound of the range.
-
-The type depends on which parser you've registered for the component type. For
-example, an `int4range` is made up of the `int4` type. By default, node-postgres
-parses `int4`s to a JS numbers. But if you've overriden this parsing with
-[pg-types][pg-types], pg-range respects this.
-
-##### `upper` *varies*
-
-The upper bound of the range. See `lower`.
-
-##### `bounds` *string*
-
-A string representing the exclusivity of the lower and upper bounds. A
-parenthesis indicates an exclusive bound, while a square bracket indicates an
-inclusive bound.
-
-Valid values: `()`, `(]`, `[)`, `[]`
-
-
-#### Methods
-
-##### `toJSON`
-
-Yields an object with the following properties:
-
-```json
-{
-  "lower": "?",
-  "upper": "?",
-  "bounds": "?"
-}
-```
-
-
-## Caveats
-
-Range objects don't support any useful operators, like `contains`, `leftOf`,
-`each`, etc. Maybe for 1.0?
+**Warning:** When constructing range objects for use in queries, use the
+pg-range `Range` constructor as shown above, and not raw stRange.js
+`Range` objects. Raw stRange.js objects do not provide a `toPostgres`
+method, and will not properly serialize date ranges and empty ranges in
+queries!
 
 [node-postgres]: https://github.com/brianc/node-postgres
 [pg-types]: https://github.com/brianc/node-pg-types
 [postgres-docs]: http://www.postgresql.org/docs/9.3/static/rangetypes.html
+[strange]: https://github.com/moll/js-strange
+[strange-docs]: https://github.com/moll/js-strange/blob/master/doc/API.md

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,6 +1,5 @@
-var util = require("util");
-
-var VALID_BOUNDS = ["[]", "[)", "(]", "()"];
+var Range = require("strange")
+  , util = require("util");
 
 function formatBound(value, prepare) {
   if (value === null) {
@@ -15,47 +14,25 @@ function formatBound(value, prepare) {
   return value;
 }
 
-function Range(lower, upper, bounds) {
-  if (!(this instanceof Range)) {
-    return new Range(lower, upper, bounds);
+function PGRange(begin, end, bounds) {
+  if (!(this instanceof PGRange)) {
+    return new PGRange(begin, end, bounds);
   }
-
-  if (!lower && !upper && !bounds) {
-    this.empty = true;
-    return;
-  }
-
-  bounds = bounds || "[)";
-  if (VALID_BOUNDS.indexOf(bounds) === -1) {
-    throw new Error(util.format("invalid bounds: %s", bounds));
-  }
-
-  this.lower = lower;
-  this.upper = upper;
-  this.bounds = bounds;
+  Range.call(this, begin, end, bounds);
 }
 
-Range.prototype.toPostgres = function (prepare) {
-  if (this.empty) {
+util.inherits(PGRange, Range);
+
+PGRange.prototype.toPostgres = function (prepare) {
+  if (this.isEmpty()) {
     return "empty";
   }
 
   return util.format("%s%s,%s%s",
     this.bounds[0],
-    formatBound(this.lower, prepare),
-    formatBound(this.upper, prepare),
+    formatBound(this.begin, prepare),
+    formatBound(this.end, prepare),
     this.bounds[1]);
 };
 
-Range.prototype.toJSON = function () {
-  if (this.empty) {
-    return { lower: null, upper: null, bounds: null };
-  }
-  return {
-    lower: this.lower,
-    upper: this.upper,
-    bounds: this.bounds
-  };
-};
-
-module.exports = Range;
+module.exports = PGRange;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sinon-chai": "^2.5.0"
   },
   "dependencies": {
-    "lodash": "^2.4.1"
+    "lodash": "^2.4.1",
+    "strange": "^1.3.0"
   }
 }

--- a/test/parser.js
+++ b/test/parser.js
@@ -21,64 +21,64 @@ describe("parser", function () {
   describe(".parseRange", function () {
     it("should parse [] finite ranges", function () {
       var range = parser.parseRange(_.identity, "[1,2]");
-      range.lower.should.equal("1");
-      range.upper.should.equal("2");
+      range.begin.should.equal("1");
+      range.end.should.equal("2");
       range.bounds.should.equal("[]");
     });
 
     it("should parse [) finite ranges", function () {
       var range = parser.parseRange(_.identity, "[1,2)");
-      range.lower.should.equal("1");
-      range.upper.should.equal("2");
+      range.begin.should.equal("1");
+      range.end.should.equal("2");
       range.bounds.should.equal("[)");
     });
 
     it("should parse (] finite ranges", function () {
       var range = parser.parseRange(_.identity, "(1,2]");
-      range.lower.should.equal("1");
-      range.upper.should.equal("2");
+      range.begin.should.equal("1");
+      range.end.should.equal("2");
       range.bounds.should.equal("(]");
     });
 
     it("should parse () finite ranges", function () {
       var range = parser.parseRange(_.identity, "(1,2)");
-      range.lower.should.equal("1");
-      range.upper.should.equal("2");
+      range.begin.should.equal("1");
+      range.end.should.equal("2");
       range.bounds.should.equal("()");
     });
 
     it("should parse quoted range bounds", function () {
       var range = parser.parseRange(_.identity, '("1, 2","3, 4")'); // jshint ignore:line
-      range.lower.should.equal("1, 2");
-      range.upper.should.equal("3, 4");
+      range.begin.should.equal("1, 2");
+      range.end.should.equal("3, 4");
     });
 
     it("should unescape quoted range bounds", function () {
       // jshint ignore:start
       var range = parser.parseRange(_.identity, '("\\"cows\\"","\\"moos\\"")');
-      range.lower.should.equal('"cows"');
-      range.upper.should.equal('"moos"');
+      range.begin.should.equal('"cows"');
+      range.end.should.equal('"moos"');
       // jshint ignore:end
     });
 
-    it("should parse lower bound infinite ranges", function () {
+    it("should parse begin bound infinite ranges", function () {
       var range = parser.parseRange(_.identity, "[,2)");
-      should.not.exist(range.lower);
-      range.upper.should.equal("2");
+      should.not.exist(range.begin);
+      range.end.should.equal("2");
       range.bounds.should.equal("[)");
     });
 
-    it("should parse upper bound infinite ranges", function () {
+    it("should parse end bound infinite ranges", function () {
       var range = parser.parseRange(_.identity, "[2,)");
-      range.lower.should.equal("2");
-      should.not.exist(range.upper);
+      range.begin.should.equal("2");
+      should.not.exist(range.end);
       range.bounds.should.equal("[)");
     });
 
     it("should parse both bound infinite ranges", function () {
       var range = parser.parseRange(_.identity, "[,)");
-      should.not.exist(range.lower);
-      should.not.exist(range.upper);
+      should.not.exist(range.begin);
+      should.not.exist(range.end);
       range.bounds.should.equal("[)");
     });
   });

--- a/test/range.js
+++ b/test/range.js
@@ -20,24 +20,12 @@ describe("Range", function () {
       }).should.not.throw();
     });
 
-    it("should reject ranges with invalid string bounds", function () {
-      (function () {
-        Range(7, 9, ")(");
-      }).should.throw(/invalid bounds/);
-    });
-
-    it("should reject ranges with non-string bounds", function () {
-      (function () {
-        Range(7, 9, {});
-      }).should.throw(/invalid bounds/);
-    });
-
-    it("should use default bounds [) if unspecified", function () {
-      Range(1, 2).bounds.should.equal("[)");
+    it("should use default bounds [] if unspecified", function () {
+      Range(1, 2).bounds.should.equal("[]");
     });
 
     it("should support empty ranges", function () {
-      Range().empty.should.be.true;
+      Range().isEmpty().should.be.true;
     });
   });
 
@@ -106,32 +94,6 @@ describe("Range", function () {
     describe("when given an empty range", function () {
       it("returns empty range literal", function () {
         toPostgres().should.equal("empty");
-      });
-    });
-  });
-
-  describe("toJSON", function () {
-    it("handles finite ranges", function () {
-      Range(1, 2, "[]").toJSON().should.deep.equal({
-        lower: 1,
-        upper: 2,
-        bounds: "[]"
-      });
-    });
-
-    it("handles infinite ranges", function () {
-      Range(null, null, "[]").toJSON().should.deep.equal({
-        lower: null,
-        upper: null,
-        bounds: "[]"
-      });
-    });
-
-    it("handles empty ranges", function () {
-      Range().toJSON().should.deep.equal({
-        lower: null,
-        upper: null,
-        bounds: null
       });
     });
   });


### PR DESCRIPTION
WIP. Problems:

* No errors when bounds invalid. This seems like a check that belongs in stRange.
* toJSON format is backwards-incompatible. @waisbrot is this a problem for WHOOP?

Fixes #3.