### PR TITLE
widen Endpoint type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module "pg-range" {
   // Must use any here as we cannot use a namespace as a type
   export function install(pg: any): void;
 
-  type Endpoint = Date | number | string;
+  type Endpoint = Date | number | string | { valueOf(): string | number };
 
   export class Range<T extends Endpoint> extends StRange<T> {
     toPostgres(prepare: any): string;


### PR DESCRIPTION
Widen `Endpoint` type to accept any primitive or object with a `valueOf` method

See updated types for upstream package `stRange`: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/62819